### PR TITLE
Improve development setup documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,26 +40,26 @@ MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 # Legacy importer
-#BS_LEGACY_IMPORT_ENABLED = false
+#BS_LEGACY_IMPORT_ENABLED=false
 #BS_DB_HOST=127.0.0.1
 #BS_DB_PORT=3306
 #BS_DB_DATABASE=beatsaver_legacy
 #BS_DB_USERNAME=beatsaver
 #BS_DB_PASSWORD=secret
-#BS_LEGACY_SONG_PATH = <PATH-TO>/beatsaver-master/files/
+#BS_LEGACY_SONG_PATH=<PATH-TO>/beatsaver-master/files/
 
-BS_LEAGAL_EMAIL = legal@beatsaver.com
+BS_LEAGAL_EMAIL=legal@beatsaver.com
 # cache duration in minutes
-#BS_SONG_CACHE_DURATION = 60
+#BS_SONG_CACHE_DURATION=60
 
 # post new uploaded songs to this discord channel
-#BS_DISCORD_WEBHOOKS_ENABLED = false
+#BS_DISCORD_WEBHOOKS_ENABLED=false
 # part after https://discordapp.com/api/webhooks/
-#BS_DISCORD_WEBHOOKS_CHANNEL =
+#BS_DISCORD_WEBHOOKS_CHANNEL=
 
 # scoresaber.com integration
 #BS_SCORESABER_AUTH_KEY=
 #BS_SCORESABER_ENABLED=false
 #BS_SCORESABER_SYNC_MIN_DOWNLOAD=100
 
-#BS_THEME = default
+#BS_THEME=default

--- a/readme.md
+++ b/readme.md
@@ -54,20 +54,51 @@ Install dependencies:
 composer install
 ```
 
+Setup required options in `php.ini`:
+
+```
+post_max_size = 16M
+upload_max_filesize = 16M
+```
+
 Setup the configuration file:
 
 ```
 cp .env.example .env
 ```
 
-Configure the database by editing `.env`
+Configure the database by editing `.env`. Recommended changes for development are:
+```
+# Use a non-persistent, in-memory cache
+CACHE_DRIVER=array
 
-Don't forget to configure the email driver. You can set `MAIL_DRIVER=log` during development.
+# Log all mail events to storage/logs/laraval.log
+# (Needed to view user registration links)
+MAIL_DRIVER=log
+```
+
+Create the database and user:
+
+```
+# Use the configured values in .env to create the user
+# These commands can also be run in the database's shell
+source .env
+echo "CREATE DATABASE \`${DB_DATABASE}\`;"\
+     "CREATE USER '${DB_USERNAME}'@localhost IDENTIFIED BY '${DB_PASSWORD}';"\
+     "GRANT ALL privileges ON \`${DB_DATABASE}\`.* TO '${DB_USERNAME}'@localhost;FLUSH PRIVILEGES;"\
+     | mysql -u root -p
+```
 
 Run setup and database migrations:
 
 ```
+# Generate an application key
 php artisan key:generate
+
+# Make stored files accessible from the web
+php artisan storage:link
+
+# Run database migrations
 php artisan migrate
 ```
 
@@ -81,7 +112,7 @@ Visit the development site:
 
 http://localhost:8080
 
-You can now register a user.
+You can now register a user and start using the application.
 
 ## License
 


### PR DESCRIPTION
Added information regarding:
 - Required `php.ini` settings
 - Setting up the database
 - Making the storage folder available from the application
 - Using the 'array' cache driver (easier for dev than memcached)
 - Where mail logs are stored and why they're needed

Slight whitespace changes to the `.env.example` file were made to allow
bash to source it, enabling an easier database setup.