### PR TITLE
Add Atom feeds for new beatmaps

### DIFF
--- a/app/Http/Controllers/FeedController.php
+++ b/app/Http/Controllers/FeedController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\SongListComposer;
+
+class FeedController extends Controller
+{
+
+    const FEED_LIMIT = 30;
+
+    /**
+     * @param SongListComposer $composer
+     *
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
+    public function newest(SongListComposer $composer)
+    {
+        return response()->view('master.atom-feed', [
+            'title' => 'Newest',
+            'songs' => $composer->getNewestSongs(0, FeedController::FEED_LIMIT),
+        ], 200)->header('Content-Type', 'application/atom+xml; charset=utf-8');
+    }
+
+    /**
+     * @param int              $id
+     * @param SongListComposer $composer
+     *
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
+    public function byUser($id, SongListComposer $composer)
+    {
+        $user = User::find($id);
+        if (!$user) {
+            abort(404);
+        }
+
+        return response()->view('master.atom-feed', [
+            'title' => 'Songs by ' . $user->name,
+            'songs' => $composer->getSongsByUser($id, 0, FeedController::FEED_LIMIT),
+        ], 200)->header('Content-Type', 'application/atom+xml; charset=utf-8');
+    }
+}

--- a/resources/views/master/atom-feed.blade.php
+++ b/resources/views/master/atom-feed.blade.php
@@ -1,0 +1,1 @@
+@includeFirst(['themes.'.config('themes.current').'.atom-feed','themes.default.atom-feed'])

--- a/resources/views/themes/bulma/layout.blade.php
+++ b/resources/views/themes/bulma/layout.blade.php
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 @yield('og-meta')
+
+@section('feeds')
+    <link href="{{ route('feeds.newest') }}" rel="alternate" title="Beat Saver - Newest" type="application/atom+xml">
+@show
+
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://unpkg.com/@lolpants/bulma@0.7.1/css/bulma.min.css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">

--- a/resources/views/themes/bulma/pages/songs/browse-by-user.blade.php
+++ b/resources/views/themes/bulma/pages/songs/browse-by-user.blade.php
@@ -1,6 +1,11 @@
 @extends('themes.bulma.layout')
 @section('title', '- Songs by '.$username)
 
+@section('feeds')
+    @parent
+    <link href="{{ route('feeds.user', ['id' => $userId]) }}" rel="alternate" title="Beat Saver @yield('title')" type="application/atom+xml">
+@endsection
+
 @section('content')
     @each('themes.bulma.pages.songs.partial-preview',$songs,'song')
     @include('themes.bulma.pages.songs.partial-paging-user')

--- a/resources/views/themes/default/atom-feed.blade.php
+++ b/resources/views/themes/default/atom-feed.blade.php
@@ -1,0 +1,36 @@
+{!! '<'.'?'.'xml version="1.0" encoding="UTF-8" ?>' !!}
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title type="text">Beat Saver - {{ $title }}</title>
+    <id>{{ Request::fullUrl() }}</id>
+    <link rel="self" type="application/atom+xml" href="{{ Request::fullUrl() }}" />
+    <icon>{{ URL::to('/favicon.ico') }}</icon>
+@foreach ($songs as $song)
+@php ($uploaderUrl = route('browse.user', ['id' => $song['uploaderId']]))
+@php ($version = $song['version'][$song['key']])
+@php ($updated = $version['createdAt']->toRfc3339String())
+@if ($loop->first)
+    <updated>{{ $updated }}</updated>
+@endif
+    <entry>
+        <id>{{ $version['linkUrl'] }}</id>
+        <title>{{ $song['name'] }}</title>
+        <updated>{{ $updated }}</updated>
+        <author>
+            <name>{{ $song['uploader'] }}</name>
+            <uri>{{ $uploaderUrl }}</uri>
+        </author>
+        <link rel="alternate" type="text/html" href="{{ $version['linkUrl'] }}"/>
+        <link rel="enclosure" type='application/zip' href="{{ $version['downloadUrl'] }}"/>
+        <summary type="html"><![CDATA[
+            <img src="{{ $version['coverUrl'] }}" width="150px"/>
+            <p>
+                Song: {{ $version['songName'] }} - {{ $version['songSubName'] }}<br/>
+                Author: {{ $version['authorName'] }}<br/>
+                Uploader: <a href="{{ $uploaderUrl }}">{{ $song['uploader'] }}</a><br/>
+                Difficulties: {{ implode(", ", array_keys($version['difficulties'])) }}<br/>
+                Version: {{ $song['key'] }}<br/>
+            </p>
+        ]]></summary>
+    </entry>
+@endforeach
+</feed>

--- a/resources/views/themes/default/layout.blade.php
+++ b/resources/views/themes/default/layout.blade.php
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=1024">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 @yield('og-meta')
+
+@section('feeds')
+    <link href="{{ route('feeds.newest') }}" rel="alternate" title="Beat Saver - Newest" type="application/atom+xml">
+@show
+
 <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
           crossorigin="anonymous">

--- a/resources/views/themes/default/pages/songs/browse-by-user.blade.php
+++ b/resources/views/themes/default/pages/songs/browse-by-user.blade.php
@@ -1,6 +1,11 @@
 @extends('themes.default.layout')
 @section('title', '- Songs by '.$username)
 
+@section('feeds')
+    @parent
+    <link href="{{ route('feeds.user', ['id' => $userId]) }}" rel="alternate" title="Beat Saver @yield('title')" type="application/atom+xml">
+@endsection
+
 @section('content')
     @each('themes.default.pages.songs.partial-preview',$songs,'song')
     @include('themes.default.pages.songs.partial-paging-user')

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,9 @@ Route::get('/browse/newest/{start?}', 'BeatSaverController@newest')->name('brows
 Route::get('/browse/detail/{key}', 'BeatSaverController@detail')->name('browse.detail');
 Route::get('/browse/byuser/{id}/{start?}', 'BeatSaverController@byUser')->name('browse.user');
 
+Route::get('/feeds/newest', 'FeedController@newest')->name('feeds.newest');
+Route::get('/feeds/byuser/{id}', 'FeedController@byUser')->name('feeds.user');
+
 Route::get('/download/{key}', 'BeatSaverController@download')->name('download');
 
 Route::post('/search', 'BeatSaverController@searchSubmit')->name('search.submit');


### PR DESCRIPTION
Inserts a link in the head of every page to a feed of newly-uploaded
beatmaps. Additionally, when viewing a specific user's uploads, a
user-specific feed will be inserted.

Browsers/browser extensions will detect this and provide a button to
subscribe to the feeds.

The feed itself contains the beatmap image, information, as well as an
enclosure link to the actual beatmap zip file. With compatible feed
readers, this will enable easy auto-downloading.

Atom was chosen over RSS because it's a much cleaner specification and
pretty much every feed reader supports both anyway.

Fixes #20