### PR TITLE
store mp3 preview files (fixes #66)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,4 +46,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if defined? VagrantPlugins::HostsUpdater
         config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
     end
+
+    config.vm.provision 'ffmpeg', type: 'shell', inline: 'apt install -y ffmpeg'
 end

--- a/app/SongComposer.php
+++ b/app/SongComposer.php
@@ -168,7 +168,7 @@ class SongComposer implements ComposerContract
           $audioFilenameBase = pathinfo($audioFilename)['filename'];
           $previewOutPath = storage_path("app/{$storagePathBase}/{$audioFilenameBase}.mp3");
           $previewTempPath = storage_path("app/{$storagePathPreview}");
-          exec("(ffmpeg -i {$previewTempPath} {$previewOutPath}; rm {$previewTempPath}) > /dev/null &");
+          exec("(ffmpeg -i \"{$previewTempPath}\" \"{$previewOutPath}\"; rm \"{$previewTempPath}\") > /dev/null &");
         }
 
         return [

--- a/app/SongComposer.php
+++ b/app/SongComposer.php
@@ -152,8 +152,15 @@ class SongComposer implements ComposerContract
             Storage::disk()->makeDirectory('public/songs/' . $song->id);
         }
 
+        // Store song image.
         File::move($file, storage_path('app/public/songs') . "/{$song->id}/{$song->id}-{$songDetails->id}.zip");
         Storage::disk()->put("public/songs/{$song->id}/{$song->id}-{$songDetails->id}.{$songData['coverType']}", base64_decode($songData['coverData']));
+
+        // Convert for preview.
+        Storage::disk()->put("public/songs/{$song->id}/tempPreview", base64_decode($songData['songPreviewData']));
+        $previewTempPath = storage_path("app/public/songs/{$song->id}/tempPreview");
+        $previewOutPath = storage_path("app/public/songs/{$song->id}/preview.mp3");
+        exec("(ffmpeg -i {$previewTempPath} {$previewOutPath}; rm ${previewTempPath}) > /dev/null &");
 
         return [
             'status' => static::SONG_CREATED,

--- a/app/SongComposer.php
+++ b/app/SongComposer.php
@@ -156,11 +156,20 @@ class SongComposer implements ComposerContract
         File::move($file, storage_path('app/public/songs') . "/{$song->id}/{$song->id}-{$songDetails->id}.zip");
         Storage::disk()->put("public/songs/{$song->id}/{$song->id}-{$songDetails->id}.{$songData['coverType']}", base64_decode($songData['coverData']));
 
-        // Convert for preview.
-        Storage::disk()->put("public/songs/{$song->id}/tempPreview", base64_decode($songData['songPreviewData']));
-        $previewTempPath = storage_path("app/public/songs/{$song->id}/tempPreview");
-        $previewOutPath = storage_path("app/public/songs/{$song->id}/preview.mp3");
-        exec("(ffmpeg -i {$previewTempPath} {$previewOutPath}; rm ${previewTempPath}) > /dev/null &");
+        // Create MP3 previews (e.g., for iOS).
+        foreach ($songData['songPreviews'] as $audioPath => $songPreviewData) {
+          // Save original song data temporarily to convert with ffmpeg.
+          $audioFilename = basename($audioPath);
+          $storagePathBase  = "public/songs/{$song->id}";
+          $storagePathPreview = "{$storagePathBase}/temp-{$audioFilename}";
+          Storage::disk()->put("$storagePathPreview", base64_decode($songPreviewData));
+
+          // Convert to MP3 with ffmpeg.
+          $audioFilenameBase = pathinfo($audioFilename)['filename'];
+          $previewOutPath = storage_path("app/{$storagePathBase}/{$audioFilenameBase}.mp3");
+          $previewTempPath = storage_path("app/{$storagePathPreview}");
+          exec("(ffmpeg -i {$previewTempPath} {$previewOutPath}; rm {$previewTempPath}) > /dev/null &");
+        }
 
         return [
             'status' => static::SONG_CREATED,

--- a/app/UploadParser.php
+++ b/app/UploadParser.php
@@ -138,9 +138,15 @@ class UploadParser
             }
 
             $hashBase = '';
+            $hasSongPreviewData = false;
             foreach ($info['difficultyLevels'] as $difficultyLevel) {
 
                 if ($this->zipHasFile($difficultyLevel['audioPath']) && $this->zipHasFile($difficultyLevel['jsonPath'])) {
+                    if (!$hasSongPreviewData) {
+                        $songData['songPreviewData'] = base64_encode($this->readFromZip($difficultyLevel['audioPath']));
+                        $hasSongPreviewData = true;
+                    }
+
                     $songData['difficultyLevels'][$difficultyLevel['difficulty']] = [
                         'difficulty' => $difficultyLevel['difficulty'],
                         'rank'       => $difficultyLevel['difficultyRank'],

--- a/app/UploadParser.php
+++ b/app/UploadParser.php
@@ -138,13 +138,14 @@ class UploadParser
             }
 
             $hashBase = '';
-            $hasSongPreviewData = false;
+            $songData['songPreviews'] = [];
             foreach ($info['difficultyLevels'] as $difficultyLevel) {
 
                 if ($this->zipHasFile($difficultyLevel['audioPath']) && $this->zipHasFile($difficultyLevel['jsonPath'])) {
-                    if (!$hasSongPreviewData) {
-                        $songData['songPreviewData'] = base64_encode($this->readFromZip($difficultyLevel['audioPath']));
-                        $hasSongPreviewData = true;
+                    // Store song preview data in object for SongComposer to save to disk.
+                    $audioPath = $difficultyLevel['audioPath'];
+                    if (!array_key_exists($audioPath, $songData['songPreviews'])) {
+                      $songData['songPreviews'][$audioPath] = base64_encode($this->readFromZip($audioPath));
                     }
 
                     $songData['difficultyLevels'][$difficultyLevel['difficulty']] = [


### PR DESCRIPTION
For reliable cross-browser audio previews and to support BeatSaver Viewer on platforms such as Safari/iOS. Went with MP3 over AAC due to Firefox support.

I guess optimally, these things would be done using a task queue, but I think the upload frequency is enough to do it on demand.

Using an exec / shell call-out vs php-ffmpeg because want to do it in background to not hold up the HTTP response.